### PR TITLE
[tests only] Fix brew-not-in-path in tests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -37,6 +37,7 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
+    - run: echo "/home/linuxbrew/.linuxbrew/bin:/home/linuxbrew/.linuxbrew/sbin" >> $GITHUB_PATH
     - name: Environment setup
       run: |
         brew install bats-core mkcert


### PR DESCRIPTION
* https://github.com/actions/runner-images/issues/6283

brew is no longer in the path, has to be added manually